### PR TITLE
Updated unit for KV rating to match code

### DIFF
--- a/docs/simplefoc_library/practical/library_units.md
+++ b/docs/simplefoc_library/practical/library_units.md
@@ -21,7 +21,7 @@ Torque/Current | `Amperes` | `A`  | Motor torque or current
 Voltage | `Volts` | `V` | Motor/Driver voltage
 Phase resistance | `Ohms` | `Ω` | Motor phase resistance
 Phase inductance | `Henries` | `H` | Motor phase inductance
-KV rating | `Radians per second per volt` | `RAD/s/V` | Motor velocity constant
+KV rating | `Rotations per minute per volt` | `rpm/V` | Motor velocity constant
 PWM frequency | `Hertz` | `Hz` | Motor/driver PWM frequency
 PMW duty cycle | `No unit` | - | All duty cycles have the range: `0 - 1.0`
 


### PR DESCRIPTION
See https://github.com/simplefoc/Arduino-FOC/blob/fb0be07488ed26db7cbc16dff0ef43c30bda818c/src/BLDCMotor.cpp#L38 and https://community.simplefoc.com/t/contradiction-between-documentation-and-source-code-regarding-kv-rating-unit/7062